### PR TITLE
Components ref link (non-existent) to Env setup

### DIFF
--- a/01-jsx/README.md
+++ b/01-jsx/README.md
@@ -76,7 +76,7 @@ Notice that instead of `class` it's `className` and `htmlFor` instead of just `f
 
 ## Next
 
-Go to [Step 2 - Components](../02-components/).
+Go to [Step 2 - Environment setup](../02-env-setup/).
 
 ## Resources
 


### PR DESCRIPTION
It is only an issue in refresh branch. Just made it same as in 'master' so it references the correct following page which is 'Environment setup'.