### PR TITLE
Fixes state variable name in instructions

### DIFF
--- a/05-email-view/README.md
+++ b/05-email-view/README.md
@@ -167,7 +167,7 @@ export default class EmailList extends PureComponent {
 }
 ```
 
-Back in `App`, add a handler for the `onItemSelect` handler in `EmailList` called `_handleItemSelect` that will update `this.state.selectedEmail` with the selected email item:
+Back in `App`, add a handler for the `onItemSelect` handler in `EmailList` called `_handleItemSelect` that will update `this.state.selectedEmailId` with the selected email item:
 
 ```js
 export default class App extends PureComponent {


### PR DESCRIPTION
Hi Ben!

Thanks for this fantastic tutorial on React! I've really enjoyed going through it. It has solidified a lot of concepts for me. During my progress, I noticed a place in the instructions that described a state variable name that did not match in the code below it. I've provided my suggested changes.

Thank you,
Sean