### PR TITLE
Add mention of style props

### DIFF
--- a/src/01-jsx/README.md
+++ b/src/01-jsx/README.md
@@ -25,56 +25,61 @@ export default class App extends Component {
 Add nested JSX markup. For example:
 
 ```js
-export default class App extends Component {
-  render() {
-    return (
-      <div>
-        <h1>Hello world!</h1>
-        <p>This is a paragraph of text written in React</p>
-      </div>
-    );
-  }
-}
+return (
+  <div>
+    <h1>Hello world!</h1>
+    <p>This is a paragraph of text written in React</p>
+  </div>
+);
 ```
 
 Add attributes to the nested JSX markup. For example:
 
 ```js
-export default class App extends Component {
-  render() {
-    return (
-      <div>
-        <h1>Hello world!</h1>
-        <p>This is a paragraph of text written in React</p>
-        <aside>
-          <input type="text" id="input" placeholder="Fill me in please" />
-        </aside>
-      </div>
-    );
-  }
-}
+return (
+  <div>
+    <h1>Hello world!</h1>
+    <p>This is a paragraph of text written in React</p>
+    <aside>
+      <input type="text" id="input" placeholder="Fill me in please" />
+    </aside>
+  </div>
+);
 ```
 
 Try adding classes to JSX markup, or a `<label>` to connect inputs:
 
 ```js
-export default class App extends Component {
-  render() {
-    return (
-      <div>
-        <h1>Hello world!</h1>
-        <p className="large">This is a paragraph of text written in React</p>
-        <aside>
-          <label htmlFor="input">Input label</label>
-          <input type="text" id="input" placeholder="Fill me in please" />
-        </aside>
-      </div>
-    );
-  }
-}
+  return (
+    <div>
+      <h1>Hello world!</h1>
+      <p className="large">This is a paragraph of text written in React</p>
+      <aside>
+        <label htmlFor="input">Input label</label>
+        <input type="text" id="input" placeholder="Fill me in please" />
+      </aside>
+    </div>
+  );
 ```
 
 Notice that instead of `class` it's `className` and `htmlFor` instead of just `for`.
+
+Lastly, add inline styles to some elements by passing an object to the `style` prop:
+
+```js
+return (
+  <div>
+    <h1 style={{fontSize: '5em'}}>Hello world!</h1>
+    <p className="large" style={{backgroundColor: 'lightgrey'}}>This is a paragraph of text written in React</p>
+    <aside>
+      <label htmlFor="input" style={{display: 'block'}}>Input label</label>
+      <input type="text" id="input" placeholder="Fill me in please" style={{color: 'blue', marginTop: '30'}} />
+    </aside>
+  </div>
+);
+```
+
+The `style` prop in React JSX takes an **object**, not a string like the HTML style property. The property names within the object are `camelCase` like JavaScript DOM notation (such as `backgroundColor`), instead of `kebab-case` like the property names in traditional CSS (such as `background-color`). If you pass a number to a property that takes a unit (such as `marginTop`), React will add `px` to the end for you.
 
 ## Exercises
 
@@ -140,6 +145,7 @@ Go to [Step 2 - Components](../02-components/).
 - [JSX in Depth](https://facebook.github.io/react/docs/jsx-in-depth.html)
 - [React without JSX](https://facebook.github.io/react/docs/react-without-jsx.html)
 - [Babel REPL](http://babeljs.io/repl/)
+- [Inline Styles](https://facebook.github.io/react/docs/dom-elements.html#style)
 
 ## Questions
 

--- a/src/09-styling/README.md
+++ b/src/09-styling/README.md
@@ -168,11 +168,11 @@ export default class App extends Component {
 }
 ```
 
-These classes help position the email list, email view and email form within the `App` component. That's why they exist within `App` and not within the individual components.
+These classes help position the email list, email view and email form within the `App` component. That's why they exist within `App` and not within the individual components. You'll find the actual CSS styling within [App.css](./App.css).
 
 When an email item is selected, you should see a 3-column layout: email list on the left, email form on the right, and email view in the center.
 
-In `EmailListItem`, add CSS classes for from & subject display elements. Wrap the delete button in `<span>` with a CSS class. Using the [`classnames`](https://github.com/JedWatson/classnames) library, conditionally add classes container element based on whether or not the email item is selected:
+In `EmailListItem`, add appropriate CSS classes for `from` & `subject` display elements. Wrap the delete button in `<span>` with a "status" CSS class. Using the [`classnames`](https://github.com/JedWatson/classnames) library, conditionally add a class to the container element based on whether or not the email item is selected:
 
 ```js
 render() {
@@ -197,7 +197,9 @@ render() {
 }
 ```
 
-You will need to import `classnames` at the top of the file:
+The CSS styling can be found in [EmailListItem.css](components/EmailListItem.css).
+
+Don't forget to import `classnames` at the top of the file:
 
 ```js
 import React, {Component} from 'react';


### PR DESCRIPTION
The Styling step goes over styling with CSS class, but never do we show how to use inline styles with the `style` prop. So this adds simple examples of using inline styles in Step 1 where we discuss JSX syntax.

Also updated some verbiage in the Step 9 - Styling README.

Fixes #29 