### PR TITLE
Add Concepts section to each step

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Star on GitHub](https://img.shields.io/github/stars/benmvp/react-workshop.svg?style=social)](https://github.com/benmvp/react-workshop/stargazers)
 [![Tweet](https://img.shields.io/twitter/url/https/github.com/benmvp/react-workshop.svg?style=social)](https://twitter.com/intent/tweet?text=Check%20out%20React%20Fundamentals%20Workshop%20by%20%40benmvp!%0A%0Ahttps%3A%2F%2Fgithub.com%2Fbenmvp%2Freact-workshop)
 
-A step-by-step workshop for learning React fundamentals. Best if accompanied with live facilitation. 🙂
+A step-by-step workshop to build a React application, all while learning React fundamentals. Best if accompanied with live facilitation. 🙂
 
 ## Many thanks!
 
@@ -87,6 +87,22 @@ You can start at the [beginning](src/00-begin/) to get setup. Afterwards follow 
 1. [Action-Reducers](src/13-action-reducers/)
 1. [Redux-y Actions and Reducers](src/14-reduxy-actions-reducers/)
 1. [Connect App and Store](src/15-connect-app-and-store/)
+
+## FUNdamental Concepts
+
+- Using JSX syntax ([Step 1](src/01-jsx/))
+- Writing readable, reusable and composable components ([Step 2](src/02-components/))
+- Maintaining component state ([Step 4](src/04-email-view/))
+- Handling user interaction ([Step 4](src/04-email-view/))
+- Handling HTML forms & form elements ([Step 5](src/05-email-form/))
+- Leveraging ES6+ to maintain application state ([Step 6](src/06-submit-email-form/))
+- Making API calls ([Step 8](src/08-api/))
+- Hooking into the component lifecycle ([Step 8](src/08-api/))
+- Applying component styling with CSS classes ([Step 9](src/09-styling/))
+- Factoring out logic from components ([Step 12](src/12-api-lib/))
+- Creating "action-reducers" ([Step 13](src/13-action-reducers/))
+- Defining Redux actions & reducers ([Step 14](src/14-reduxy-actions-reducers/))
+- Conect React to Redux store ([Step 15](src/15-connect-app-and-store/))
 
 ## Questions
 

--- a/src/01-jsx/README.md
+++ b/src/01-jsx/README.md
@@ -8,6 +8,16 @@ Unlike browser DOM elements, React elements are plain objects, and are cheap to 
 
 If you run into trouble with the [tasks](#tasks) or [exercises](#exercises), you can take a peek at the final [source code](./).
 
+## Jump Around
+
+[Concepts](#concepts) | [Tasks](#tasks) | [Resources](#resources)
+
+## Concepts
+
+- Rendering elements with JSX
+- Handling special element attribute names
+- Adding inline styles
+
 ## Tasks
 
 In [`App.js`](App.js), replace `null` with JSX markup. For example:

--- a/src/02-components/README.md
+++ b/src/02-components/README.md
@@ -6,6 +6,16 @@ Conceptually, components are like JavaScript functions. They accept arbitrary in
 
 Once again, if you run into trouble with the [tasks](#tasks) or [exercises](#exercises), you can take a peek at the final [source code](./).
 
+## Jump Around
+
+[Concepts](#concepts) | [Restart Setup](#restart-setup) | [Tasks](#tasks) | [Resources](#resources)
+
+## Concepts
+
+- Creating and composing React components
+- Configuring components via passing props
+- Typechecking props
+
 ## Restart Setup
 
 If you didn't successfully complete the previous step, you can jump right in by copying the step.
@@ -194,7 +204,7 @@ const EmailListItem = ({from, subject}) => (
 );
 ```
 
-But we'll continue to use the `class` syntax so that we can define [`propTypes`](https://facebook.github.io/react/docs/typechecking-with-proptypes.html) for `EmailListItem` (and to manage `state` later on):
+The are called "stateless" function because they don't maintain their own state. We'll cover state in [Step 4](../04-email-view/). But we'll continue to use the `class` syntax so that we can define [`propTypes`](https://facebook.github.io/react/docs/typechecking-with-proptypes.html) for `EmailListItem` (and to manage `state` later on):
 
 ```js
 // back up top add new import of `prop-types` lib

--- a/src/03-lists/README.md
+++ b/src/03-lists/README.md
@@ -4,6 +4,15 @@ The goal of this step is to practice transforming lists of data into lists of co
 
 As always, if you run into trouble with the [tasks](#tasks) or [exercises](#exercises), you can take a peek at the final [source code](./).
 
+## Jump Around
+
+[Concepts](#concepts) | [Restart Setup](#restart-setup) | [Tasks](#tasks) | [Resources](#resources)
+
+## Concepts
+
+- Rendering dynamic lists of data
+- Handling special `key` prop
+
 ## Restart Setup
 
 If you didn't successfully complete the previous step, you can jump right in by copying the step.

--- a/src/04-email-view/README.md
+++ b/src/04-email-view/README.md
@@ -2,14 +2,21 @@
 
 The goal of this step is to build some interactivity into the app by responding to user interactions. [Handling events](https://facebook.github.io/react/docs/handling-events.html) within React elements is very similar to handling events on DOM elements. Event handlers will be passed instances of [`SyntheticEvent`](https://reactjs.org/docs/events.html), a cross-browser wrapper around the browser's native event. It has the same interface as the browser's native event (including` stopPropagation()` and `preventDefault()`) except the events work identically across all browsers!
 
-Ultimately, we want to click on an email list item and have its details displayed in the email view. While this a relatively simple user interaction, we'll ultimately learn about four key parts of React development:
-
-- Maintaining state
-- Passing event handlers down the compnoent hierarchy
-- Conditionally rendering components
-- Rendering unencoded content
+Ultimately, we want to click on an email list item and have its details displayed in the email view.
 
 As always, if you run into trouble with the [tasks](#tasks) or [exercises](#exercises), you can take a peek at the final [source code](./).
+
+## Jump Around
+
+[Concepts](#concepts) | [Restart Setup](#restart-setup) | [Tasks](#tasks) | [Resources](#resources)
+
+## Concepts
+
+- Maintaining application and UI state
+- Handling user interaction
+- Passing event handlers down the component hierarchy
+- Conditionally rendering components
+- Rendering unencoded content
 
 ## Restart Setup
 

--- a/src/05-email-form/README.md
+++ b/src/05-email-form/README.md
@@ -4,6 +4,14 @@ The goal of this step is learning how to deal with forms. HTML form elements wor
 
 As always, if you run into trouble with the [tasks](#tasks) or [exercises](#exercises), you can take a peek at the final [source code](./).
 
+## Jump Around
+
+[Concepts](#concepts) | [Restart Setup](#restart-setup) | [Tasks](#tasks) | [Resources](#resources)
+
+## Concepts
+
+- Handling HTML form elements
+
 ## Restart Setup
 
 If you didn't successfully complete the previous step, you can jump right in by copying the step.

--- a/src/06-submit-email-form/README.md
+++ b/src/06-submit-email-form/README.md
@@ -4,6 +4,17 @@ The goal of this step is to "send" the email and have it added to the email list
 
 As always, if you run into trouble with the [tasks](#tasks) or [exercises](#exercises), you can take a peek at the final [source code](./).
 
+## Jump Around
+
+[Concepts](#concepts) | [Restart Setup](#restart-setup) | [Tasks](#tasks) | [Resources](#resources)
+
+## Concepts
+
+- Handling client-side form submission
+- Working with the "Virtual DOM"
+- Leveraging ES6+ to maintain application state
+
+
 ## Restart Setup
 
 If you didn't successfully complete the previous step, you can jump right in by copying the step.

--- a/src/07-delete-email/README.md
+++ b/src/07-delete-email/README.md
@@ -4,6 +4,16 @@ The goal of this step is to add support for deleting individual emails in the UI
 
 As always, if you run into trouble with the [tasks](#tasks) or [exercises](#exercises), you can take a peek at the final [source code](./).
 
+## Jump Around
+
+[Concepts](#concepts) | [Restart Setup](#restart-setup) | [Tasks](#tasks) | [Resources](#resources)
+
+## Concepts
+
+- Handling user interaction
+- Leveraging ES6+ to maintain application state
+- Working with the "Virtual DOM"
+
 ## Restart Setup
 
 If you didn't successfully complete the previous step, you can jump right in by copying the step.

--- a/src/08-api/README.md
+++ b/src/08-api/README.md
@@ -4,6 +4,16 @@ The goal of this step is to move away from the hard-coded `EMAILS` constant to i
 
 As always, if you run into trouble with the [tasks](#tasks) or [exercises](#exercises), you can take a peek at the final [source code](./).
 
+## Jump Around
+
+[Concepts](#concepts) | [Restart Setup](#restart-setup) | [API Setup](#api-setup) | [Tasks](#tasks) | [Resources](#resources)
+
+## Concepts
+
+- Making API calls
+- Using Promises
+- Hooking into the component lifecycle
+
 ## Restart Setup
 
 If you didn't successfully complete the previous step, you can jump right in by copying the step.

--- a/src/09-styling/README.md
+++ b/src/09-styling/README.md
@@ -4,6 +4,15 @@ The goal of this step is to apply CSS styling to all of the components. There ar
 
 As always, if you run into trouble with the [tasks](#tasks) or [exercises](#exercises), you can take a peek at the final [source code](./).
 
+## Jump Around
+
+[Concepts](#concepts) | [Restart Setup](#restart-setup) | [Tasks](#tasks) | [Resources](#resources)
+
+## Concepts
+
+- Applying component styling with CSS classes
+- Conditionally apply CSS classes based on logic
+
 ## Restart Setup
 
 If you didn't successfully complete the previous step, you can jump right in by copying the step.

--- a/src/10-mark-unread/README.md
+++ b/src/10-mark-unread/README.md
@@ -4,6 +4,16 @@ The goal of this step is to add support for marking an email read or unread by s
 
 As always, if you run into trouble with the [tasks](#tasks) or [exercises](#exercises), you can take a peek at the final [source code](./).
 
+## Jump Around
+
+[Concepts](#concepts) | [Restart Setup](#restart-setup) | [Tasks](#tasks) | [Resources](#resources)
+
+## Concepts
+
+- Making API calls
+- Combining sections of UI into helper components
+- Handling user interaction
+
 ## Restart Setup
 
 If you didn't successfully complete the previous step, you can jump right in by copying the step.

--- a/src/11-email-form-modal/README.md
+++ b/src/11-email-form-modal/README.md
@@ -4,6 +4,16 @@ The goal of this step is to move the email form into a modal so that there is mo
 
 As always, if you run into trouble with the [tasks](#tasks) or [exercises](#exercises), you can take a peek at the final [source code](./).
 
+## Jump Around
+
+[Concepts](#concepts) | [Restart Setup](#restart-setup) | [Tasks](#tasks) | [Resources](#resources)
+
+## Concepts
+
+- Combining sections of UI into helper components
+- Handling user interaction
+- Maintaining application and UI state
+
 ## Restart Setup
 
 If you didn't successfully complete the previous step, you can jump right in by copying the step.

--- a/src/12-api-lib/README.md
+++ b/src/12-api-lib/README.md
@@ -4,6 +4,15 @@ Now that we've built out all of the UI functionality, the `App` component is doi
 
 As always, if you run into trouble with the [tasks](#tasks) or [exercises](#exercises), you can take a peek at the final [source code](./).
 
+## Jump Around
+
+[Concepts](#concepts) | [Restart Setup](#restart-setup) | [Tasks](#tasks) | [Resources](#resources)
+
+## Concepts
+
+- Factoring out logic from components
+- Centralizing API calls
+
 ## Restart Setup
 
 If you didn't successfully complete the previous step, you can jump right in by copying the step.

--- a/src/13-action-reducers/README.md
+++ b/src/13-action-reducers/README.md
@@ -6,6 +6,15 @@ The goal of these action-reducer is to perform an API call and then return a `Pr
 
 As always, if you run into trouble with the [tasks](#tasks) or [exercises](#exercises), you can take a peek at the final [source code](./).
 
+## Jump Around
+
+[Concepts](#concepts) | [Restart Setup](#restart-setup) | [Tasks](#tasks) | [Resources](#resources)
+
+## Concepts
+
+- Factoring out logic from components
+- Creating "action-reducers"
+
 ## Restart Setup
 
 If you didn't successfully complete the previous step, you can jump right in by copying the step.

--- a/src/14-reduxy-actions-reducers/README.md
+++ b/src/14-reduxy-actions-reducers/README.md
@@ -12,6 +12,16 @@ Lets implement this in our app.
 
 As always, if you run into trouble with the [tasks](#tasks) or [exercises](#exercises), you can take a peek at the final [source code](./).
 
+## Jump Around
+
+[Concepts](#concepts) | [Restart Setup](#restart-setup) | [Tasks](#tasks) | [Resources](#resources)
+
+## Concepts
+
+- Defining Redux actions & action creators
+- Defining Redux reducers
+- Using `redux-thunk` for asynchronous actions
+
 ## Restart Setup
 
 If you didn't successfully complete the previous step, you can jump right in by copying the step.

--- a/src/15-connect-app-and-store/README.md
+++ b/src/15-connect-app-and-store/README.md
@@ -17,6 +17,15 @@ In this step we are going to finish the remaining tasks in order to connect our 
 
 As always, if you run into trouble with the [tasks](#tasks) or [exercises](#exercises), you can take a peek at the final [source code](./).
 
+## Jump Around
+
+[Concepts](#concepts) | [Restart Setup](#restart-setup) | [Tasks](#tasks) | [Resources](#resources)
+
+## Concepts
+
+- Setting up a Redux store
+- Connecting React to Redux
+
 ## Restart Setup
 
 If you didn't successfully complete the previous step, you can jump right in by copying the step.


### PR DESCRIPTION
Adds a `Concepts` section to the top of each step.

The workshop steps are broken up by app functionality, where each step aims to teach one or more React concepts. By adding a `Concepts` section, it'll be clear what React fundamentals we're learning in the step while building out the piece of app functionality.

Also adding a `Jump Around` section with anchor links to different sections of the step.

Lastly added a `FUNdamental Concepts` section to the home page which lists all of the concepts, mentioning the step where they are covered.

Fixes #33